### PR TITLE
Use cairosvg<2 for any python<3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "CairoSVG" %}
-{% set version = "2.4.2" %}
+{% set version = "1.0.22" %}
 
 package:
   name: {{ name|lower }}
@@ -7,22 +7,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4e668f96653326780036ebb0a9ff2bb59a8443d7bcfc51a14aab77b57a8e67ad
+  sha256: f66e0f3a2711d2e36952bb370fcd45837bfedce2f7882935c46c45c018a21557
 
 build:
   number: 0
   noarch: python
   entry_points:
-    - cairosvg = cairosvg.__main__:main
+    - cairosvg = cairosvg.__init__:main
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
-    - python >=3.5
+    - python <3
     - pip
     - pytest-runner
   run:
-    - python >=3.5
+    - python <3
+    - pycairo
     - cairocffi
     - cssselect2
     - pillow
@@ -39,7 +40,7 @@ about:
   home: http://www.cairosvg.org/
   license: LGPL-3.0
   license_family: LGPL
-  license_file: LICENSE
+  license_file: COPYING
   summary: 'A Simple SVG Converter based on Cairo'
   doc_url: http://www.cairosvg.org/documentation
   dev_url: https://github.com/Kozea/CairoSVG


### PR DESCRIPTION
Per the CairoSVG change log, support for Python 2 was dropped at
cairosvg==2.0.0.  The last version that supported python2.x was 1.0.22

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Per #22.
@conda-forge-admin, please rerender