### PR TITLE
Build CairoSVG 1.0.22, needed for python<3

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -4,3 +4,9 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,9 @@ requirements:
     - pip
     - pytest-runner
   run:
-    - python
+    - python <3 # Without this the tests are run in a py35
+                # environment and one test fails
+                # TODO:  Find which dependency is the real culprit
     - pycairo
     - cairocffi
     - lxml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,19 @@ requirements:
     - tinycss
 
 test:
+  requires:
+    - git
   imports:
     - cairosvg
   commands:
     - cairosvg --help
+    - git clone --single-branch --branch {{ version }} https://github.com/Kozea/CairoSVG.git
+    - cd CairoSVG/test # Needed for SVGs that use relative paths
+    - find ./svg -maxdepth 1 -type f -name '*.svg' -exec echo {} \; -exec cairosvg -u {} -o {}.png \;
+    - find ./svg -maxdepth 1 -type f -name '*.svg' -exec test ! -s {}.png \; -exec touch a_test_failed \;
+    - find ./svg -maxdepth 1 -type f -name '*.svgz' -exec echo {} \; -exec cairosvg -u {} -o {}.png \;
+    - find ./svg -maxdepth 1 -type f -name '*.svgz' -exec test ! -s {}.png \; -exec touch a_test_failed \;
+    - test ! -e a_test_failed
 
 about:
   home: http://www.cairosvg.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "CairoSVG" %}
-{% set version = "2.4.2" %}
+{% set version = "1.0.22" %}
 
 package:
   name: {{ name|lower }}
@@ -7,27 +7,27 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4e668f96653326780036ebb0a9ff2bb59a8443d7bcfc51a14aab77b57a8e67ad
+  sha256: f66e0f3a2711d2e36952bb370fcd45837bfedce2f7882935c46c45c018a21557
 
 build:
   number: 0
   noarch: python
   entry_points:
-    - cairosvg = cairosvg.__main__:main
+    - cairosvg = cairosvg.__init__:main
   script: "{{ PYTHON }} -m pip install . -vv"
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pip
     - pytest-runner
   run:
-    - python >=3.5
+    - python
+    - pycairo
     - cairocffi
-    - cssselect2
-    - pillow
-    - tinycss2
-    - defusedxml
+    - lxml
+    - cssselect
+    - tinycss
 
 test:
   imports:
@@ -39,7 +39,7 @@ about:
   home: http://www.cairosvg.org/
   license: LGPL-3.0
   license_family: LGPL
-  license_file: LICENSE
+  license_file: COPYING
   summary: 'A Simple SVG Converter based on Cairo'
   doc_url: http://www.cairosvg.org/documentation
   dev_url: https://github.com/Kozea/CairoSVG


### PR DESCRIPTION
Per the CairoSVG change log, support for Python 2 was dropped at cairosvg==2.0.0.  The last version that supported `python<3` was 1.0.22.

This recipe also includes all optional dependencies.

Fixes Issue #22

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
1.0.22 has three optional dependencies and two required.