### PR TITLE
Remove latest package from py2 environment solving

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 4e668f96653326780036ebb0a9ff2bb59a8443d7bcfc51a14aab77b57a8e67ad
 
 build:
-  number: 0
-  noarch: python
+  number: 1
   entry_points:
     - cairosvg = cairosvg.__main__:main
   script: "{{ PYTHON }} -m pip install . -vv"


### PR DESCRIPTION
rollback
https://github.com/conda-forge/cairosvg-feedstock/commit/689fa7b6872be99d028dd69faec572b426bce3f1
as python>=3.5 restriction requires the noarch line to be removed.

see https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#architecture-independent-packages
> For pure Python packages that can run on any Python version, you can use the noarch: python value instead

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
